### PR TITLE
Corrected test error in accuracy-plot.R

### DIFF
--- a/tests/testthat/_snaps/accuracy_plot/accuracy-plot.svg
+++ b/tests/testthat/_snaps/accuracy_plot/accuracy-plot.svg
@@ -33,6 +33,7 @@
 <polyline points='38.15,32.69 714.52,32.69 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
 <polyline points='242.47,540.28 242.47,26.01 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
 <polyline points='496.75,540.28 496.75,26.01 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='686.97,540.28 686.97,26.01 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
 <polyline points='38.15,450.11 714.52,450.11 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
 <polyline points='38.15,283.14 714.52,283.14 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
 <polyline points='38.15,116.17 714.52,116.17 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />


### PR DESCRIPTION
I deleted old accuracy-plot.svg files because there was a mismatch between the old svg and new svg file after some fix was made to the accuracy-plot. I reran tests and all tests run.